### PR TITLE
Abstract site globals

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,9 @@
+title:        Hyde
+tagline:      "Hyde, a Jekyll theme"
+url:          http://andhyde.com
+author:
+  name:       ""
+  email:      ""
 markdown:     rdiscount
 permalink:    pretty
 pygments:     true

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,7 +8,7 @@
 
     <title>
       {% if page.title %}{{ page.title }} &middot; {% endif %}
-      Hyde, a Jekyll theme
+      {{ site.tagline }}
     </title>
 
     <!-- CSS -->
@@ -39,7 +39,7 @@
             </li>
             <li>Currently v1.0</li>
           </ul>
-          <p>&copy; 2013. All rights reserved.</p>
+          <p>&copy; 2013. {{ site.author.name }} All rights reserved.</p>
         </div>
 
       </div>

--- a/atom.xml
+++ b/atom.xml
@@ -5,20 +5,20 @@ layout: nil
 <?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">
 
- <title>Mark Otto</title>
+ <title>{{ site.title }}</title>
  <link href="http://www.markdotto.com/atom.xml" rel="self"/>
  <link href="http://www.markdotto.com/"/>
  <updated>{{ site.time | date_to_xmlschema }}</updated>
- <id>http://www.markdotto.com/</id>
+ <id>{{ site.url }}</id>
  <author>
-   <name>Mark Otto</name>
-   <email>markdotto@gmail.com</email>
+   <name>{{ site.author.name }}</name>
+   <email>{{ site.author.email }}</email>
  </author>
 
  {% for post in site.posts %}
  <entry>
    <title>{{ post.title }}</title>
-   <link href="http://www.markdotto.com{{ post.url }}"/>
+   <link href="{{ site.url }}{{ post.url }}"/>
    <updated>{{ post.date | date_to_xmlschema }}</updated>
    <id>http://www.markdotto.com{{ post.id }}</id>
    <content type="html">{{ post.content | xml_escape }}</content>


### PR DESCRIPTION
Move global settings like the site name and author to `_config.yml` for easier customization... otherwise they're somewhat buried in `atom.xml` and the header... super easy to overlook.
