### PR TITLE
Fix relative url in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ To use a theme, add anyone of the available theme classes to the `<body>` elemen
 </body>
 ```
 
-To create your own theme, look to the Themes section of [Hyde's CSS](/mdo/hyde/blob/master/public/css/hyde.css). Copy any existing theme (they're only a few lines of CSS), rename it, and change the provided colors.
+To create your own theme, look to the Themes section of [Hyde's CSS](public/css/hyde.css). Copy any existing theme (they're only a few lines of CSS), rename it, and change the provided colors.
 
 ### Reverse layout
 


### PR DESCRIPTION
The reference to `hyde.css` resulted in 404 :)
