### PR TITLE
Change markdown engine from rdiscount to redcarpet

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,7 +6,7 @@ version:      1.1.1
 author:
   name:       ''
   email:      ''
-markdown:     rdiscount
+markdown:     redcarpet
 permalink:    pretty
 pygments:     true
 paginate:     5


### PR DESCRIPTION
As discussed with regards to mdo/hyde here is the pull request for switching the markdown engine
from rdiscount to redcarpet. However now that the repos have moved I'm not sure which you
want me to submit this to so I'm submitting it to all the things, accept or deny as desired.
