### PR TITLE
The sidebar link hover and focus selectors have been fixed.

### DIFF
--- a/public/css/hyde.css
+++ b/public/css/hyde.css
@@ -91,8 +91,8 @@ html {
 .sidebar-nav-item {
   display: block;
 }
-a.sidebar-nav-item:hover,
-a.sidebar-nav-item:focus {
+.sidebar-nav-item a:hover,
+.sidebar-nav-item a:focus {
   text-decoration: underline;
 }
 .sidebar-nav-item.active {


### PR DESCRIPTION
When making some modifications to the styling of a site built on Hyde, I noticed the sidebar nav links weren't corresponding to my changes. It turns out the selectors aren't quite right. It was hardly noticeable though because their styling falls back on `poole.css` which uses the same default style.
