### PR TITLE
Update _config.yml to remove deprecation warning in Jekyll 2.0

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,6 @@
 # Dependencies
 markdown:         redcarpet
-pygments:         true
+highlighter:      pygments
 
 # Permalinks
 permalink:        pretty


### PR DESCRIPTION
Ran perfectly for me. Just this one deprecation warning.

```
~/jekyll/jekyll/hyde$ local-jekyll build --trace
Executing '/Users/parker/jekyll/jekyll/bin/jekyll build --trace'...
Configuration file: /Users/parker/jekyll/jekyll/hyde/_config.yml
       Deprecation: The 'pygments' configuration option has been renamed to 'highlighter'. Please update your config file accordingly. The allowed values are 'rouge', 'pygments' or null.
            Source: /Users/parker/jekyll/jekyll/hyde
       Destination: /Users/parker/jekyll/jekyll/hyde/_site
      Generating...
                    done.
```

Fixes #40.
