### PR TITLE
Update _config.yml file to remove deprecation warning for Jekyll 2.x

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,6 @@
 # Dependencies
 markdown:         redcarpet
-pygments:         true
+highlighter:      pygments
 
 # Permalinks
 permalink:        pretty


### PR DESCRIPTION
This was fixed in PR #41 but got reverted by https://github.com/poole/hyde/commit/802cbd1debc931719a3383324796772a58d7e3eb

So I'm trying to get it up-to-date with Jekyll 2.x again.
