### PR TITLE
update to fix build warnings

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,6 @@
 # Dependencies
 markdown:         redcarpet
-pygments:         true
+highlighter:      pygments
 
 # Permalinks
 permalink:        pretty

--- a/atom.xml
+++ b/atom.xml
@@ -1,5 +1,4 @@
 ---
-layout: nil
 ---
 
 <?xml version="1.0" encoding="utf-8"?>


### PR DESCRIPTION
config update for deprecated option

```
Deprecation: The 'pygments' configuration option has been renamed to 'highlighter'. Please update your config file accordingly. The allowed values are 'rouge', 'pygments' or null.
```

removed layout front matter to get rid of build warning for atom.xml

```
Build Warning: Layout 'nil' requested in atom.xml does not exist.
```
