### PR TITLE
fix reverse layout link to point to hyde repo

### DIFF
--- a/_posts/2013-12-28-introducing-hyde.md
+++ b/_posts/2013-12-28-introducing-hyde.md
@@ -21,7 +21,7 @@ Poole is the Jekyll Butler, serving as an upstanding and effective foundation fo
 In addition to the features of Poole, Hyde adds the following:
 
 * Sidebar includes support for textual modules and a dynamically generated navigation with active link support
-* Two orientations for content and sidebar, default (left sidebar) and [reverse](https://github.com/poole/lanyon#reverse-layout) (right sidebar), available via `<body>` classes
+* Two orientations for content and sidebar, default (left sidebar) and [reverse](https://github.com/poole/hyde#reverse-layout) (right sidebar), available via `<body>` classes
 * [Eight optional color schemes](https://github.com/poole/hyde#themes), available via `<body>` classes
 
 [Head to the readme](https://github.com/poole/hyde#readme) to learn more.


### PR DESCRIPTION
I noticed that the reverse layout link was pointing to Lanyon's README instead of of Hyde's.