### PR TITLE
Remove xmlns, unnecessary HTML5 attribute

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en-us">
+<html lang="en-us">
 
   {% include head.html %}
 


### PR DESCRIPTION
This attribute breaks s3 website hosting.  See https://github.com/laurilehmijoki/s3_website/issues/128 for screenshot.