### PR TITLE
Change baseurl from '/' to '' as per Jekyll norm

### DIFF
--- a/404.html
+++ b/404.html
@@ -6,5 +6,5 @@ permalink: 404.html
 
 <div class="page">
   <h1 class="page-title">404: Page not found</h1>
-  <p class="lead">Sorry, we've misplaced that URL or it's pointing to something that doesn't exist. <a href="{{ site.baseurl }}">Head back home</a> to try finding it again.</p>
+  <p class="lead">Sorry, we've misplaced that URL or it's pointing to something that doesn't exist. <a href="{{ site.baseurl }}/">Head back home</a> to try finding it again.</p>
 </div>

--- a/_config.yml
+++ b/_config.yml
@@ -11,7 +11,7 @@ title:            Hyde
 tagline:          'A Jekyll theme'
 description:      'A brazen two-column <a href="http://jekyllrb.com" target="_blank">Jekyll</a> theme that pairs a prominent sidebar with uncomplicated content. Made by <a href="https://twitter.com/mdo" target="_blank">@mdo</a>.'
 url:              http://hyde.getpoole.com
-baseurl:          /
+baseurl:          ''
 
 author:
   name:           'Mark Otto'

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -15,14 +15,14 @@
   </title>
 
   <!-- CSS -->
-  <link rel="stylesheet" href="{{ site.baseurl }}public/css/poole.css">
-  <link rel="stylesheet" href="{{ site.baseurl }}public/css/syntax.css">
-  <link rel="stylesheet" href="{{ site.baseurl }}public/css/hyde.css">
+  <link rel="stylesheet" href="{{ site.baseurl }}/public/css/poole.css">
+  <link rel="stylesheet" href="{{ site.baseurl }}/public/css/syntax.css">
+  <link rel="stylesheet" href="{{ site.baseurl }}/public/css/hyde.css">
   <link rel="stylesheet" href="http://fonts.googleapis.com/css?family=PT+Sans:400,400italic,700|Abril+Fatface">
 
   <!-- Icons -->
-  <link rel="apple-touch-icon-precomposed" sizes="144x144" href="{{ site.baseurl }}public/apple-touch-icon-144-precomposed.png">
-                                 <link rel="shortcut icon" href="{{ site.baseurl }}public/favicon.ico">
+  <link rel="apple-touch-icon-precomposed" sizes="144x144" href="{{ site.baseurl }}/public/apple-touch-icon-144-precomposed.png">
+                                 <link rel="shortcut icon" href="{{ site.baseurl }}/public/favicon.ico">
 
   <!-- RSS -->
   <link rel="alternate" type="application/rss+xml" title="RSS" href="/atom.xml">

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -2,7 +2,7 @@
   <div class="container sidebar-sticky">
     <div class="sidebar-about">
       <h1>
-        <a href="{{ site.baseurl }}">
+        <a href="{{ site.baseurl }}/">
           {{ site.title }}
         </a>
       </h1>
@@ -10,7 +10,7 @@
     </div>
 
     <nav class="sidebar-nav">
-      <a class="sidebar-nav-item{% if page.url == site.baseurl %} active{% endif %}" href="{{ site.baseurl }}">Home</a>
+      <a class="sidebar-nav-item{% if page.url == site.baseurl %} active{% endif %}" href="{{ site.baseurl }}/">Home</a>
 
       {% comment %}
         The code below dynamically generates a sidebar nav of pages with


### PR DESCRIPTION
I have been trying to use [Jekyll Sitemap](https://github.com/jekyll/jekyll-sitemap) against my Hyde based site and have faced issues with this line of code in `_config.yml`:

`baseurl:    /`

The problem is that [Jekyll Sitemap](https://github.com/jekyll/jekyll-sitemap) creates `sitemap.xml` file with incorrect urls (note the double `//`):

```
<url>
<loc>
http://www.jonbartlett.org//notes/dave-yates-frame-building/
</loc>
<lastmod>2014-09-30T00:00:00+00:00</lastmod>
</url>
<url>
<loc>http://www.jonbartlett.org//404.html</loc>
```

Looking around at other Jekyll sites the `baseurl` is set to `''` in most cases. The [Lanyon theme](https://github.com/poole/lanyon) is configured like this.

Also when running `jekyll serve` this fires up on `Server address: http://127.0.0.1:4000//`. Note the trailing slash.

Pull request addresses these issues by modifying `_config.yml` and updating files that reference `baseurl`.
