### PR TITLE
Using Jekyll default markdown engine - kramdown

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,3 @@
-# Dependencies
-markdown:         redcarpet
-highlighter:      pygments
-
 # Permalinks
 permalink:        pretty
 relative_permalinks: true


### PR DESCRIPTION
Redcarpet lacks features like creating tables with markdown, kramdown is superior and now the default.
