### PR TITLE
Removed relative_permalinks (Jekyll 3.x)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,7 +4,7 @@ highlighter:      pygments
 
 # Permalinks
 permalink:        pretty
-relative_permalinks: true
+#relative_permalinks: true
 
 # Setup
 title:            Hyde


### PR DESCRIPTION
relative_permalinks are no longer supported on Jekyll 3.x
