### PR TITLE
include gems: [jekyll-paginate] to _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -24,3 +24,5 @@ version:          2.1.0
 
 github:
   repo:           https://github.com/poole/hyde
+
+gems:             [jekyll-paginate]


### PR DESCRIPTION
Add **gems: [jekyll-paginate]** to _config.yml to remove the depreciation notice on jekyll build.

"Deprecation: You appear to have pagination turned on, but you haven't included the jekyll-paginate gem. Ensure you have gems: [jekyll-paginate] in your configuration file."
