### PR TITLE
Fix depreciation issues on jekyll build

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,7 +4,7 @@ highlighter:      pygments
 
 # Permalinks
 permalink:        pretty
-relative_permalinks: true
+relative_permalinks: false
 
 # Setup
 title:            Hyde

--- a/_config.yml
+++ b/_config.yml
@@ -25,4 +25,4 @@ version:          2.1.0
 github:
   repo:           https://github.com/poole/hyde
 
-gems:             [jekyll-paginate]
+gems:             [jekyll-paginate, jekyll-gist]

--- a/_config.yml
+++ b/_config.yml
@@ -24,3 +24,5 @@ version:          2.1.0
 
 github:
   repo:           https://github.com/poole/hyde
+
+gems:             [jekyll-paginate]


### PR DESCRIPTION
Add jekyll-gist gem to fix gist tag error:

"Liquid Exception: Liquid syntax error: Unknown tag 'gist' in /Users/john/projects/hyde/_posts/2012-02-07-example-content.md"

---

Disable relative_permalinks as breaks example content:

"Since v3.0, permalinks for pages in subfolders must be relative to the site source directory, not the parent directory. Check http://jekyllrb.com/docs/upgrading/ for more info."

More: https://github.com/poole/poole/issues/99

---

Third commit is part of pull request https://github.com/poole/hyde/pull/134 but adds the missing jekyll-paginate gem to remove the message:

"Deprecation: You appear to have pagination turned on, but you haven't included the `jekyll-paginate` gem. Ensure you have `gems: [jekyll-paginate]` in your configuration file."
