### PR TITLE
Update _config.yml (Jekyll 3.0 update)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,6 @@
 # Dependencies
 markdown:         redcarpet
-highlighter:      pygments
+highlighter:      rouge
 
 # Permalinks
 permalink:        pretty


### PR DESCRIPTION
There isn't a lot of changes in Jekyll 3.0, but we need to adapt Hyde to this version.

This fixes #142 (highlighter not supported)
