### PR TITLE
Correct the config file for Jekyll v3.0+

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,7 +4,6 @@ highlighter:      pygments
 
 # Permalinks
 permalink:        pretty
-relative_permalinks: true
 
 # Setup
 title:            Hyde

--- a/_config.yml
+++ b/_config.yml
@@ -24,4 +24,4 @@ version:          2.1.0
 github:
   repo:           https://github.com/poole/hyde
 
-gems: [jekyll-paginate]
+gems: [jekyll-paginate, jekyll-gist]

--- a/_config.yml
+++ b/_config.yml
@@ -24,3 +24,5 @@ version:          2.1.0
 
 github:
   repo:           https://github.com/poole/hyde
+
+gems: [jekyll-paginate]


### PR DESCRIPTION
Relative permalinks are not allowed in Jekyll 3.0+
Gem include options missing in _config.yml for gist and paginate.
