### PR TITLE
Update config for Jekyll 3.0

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,10 +1,9 @@
 # Dependencies
-markdown:         redcarpet
-highlighter:      pygments
+kramdown:         redcarpet
+highlighter:      rouge
 
 # Permalinks
 permalink:        pretty
-relative_permalinks: true
 
 # Setup
 title:            Hyde


### PR DESCRIPTION
- Jekyll's default markdown engine is now Kramdown; 
- Jekyll's default highlighter is now Rouge
- Jekyll no longer supports relative permalinks.

[Github's summary of changes in 3.0](https://github.com/blog/2100-github-pages-now-faster-and-simpler-with-jekyll-3-0)
