### PR TITLE
Consistently identify the home page by checking for node.title == null

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -10,7 +10,7 @@
     </div>
 
     <nav class="sidebar-nav">
-      <a class="sidebar-nav-item{% if page.url == site.baseurl %} active{% endif %}" href="{{ site.baseurl }}">Home</a>
+      <a class="sidebar-nav-item{% if node.title == null %} active{% endif %}" href="{{ site.baseurl }}/">Home</a>
 
       {% comment %}
         The code below dynamically generates a sidebar nav of pages with


### PR DESCRIPTION
Use `node.title == null` to determine if a page is the home page. This is consistent with the logic lower down in the file.
