### PR TITLE
expressed pagination href by pagination attributes

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,15 +21,13 @@ title: Home
 
 <div class="pagination">
   {% if paginator.next_page %}
-    <a class="pagination-item older" href="{{ site.baseurl }}page{{paginator.next_page}}">Older</a>
+    <a class="pagination-item older" href="{{ paginator.next_page_path }}">Older</a>
   {% else %}
     <span class="pagination-item older">Older</span>
   {% endif %}
   {% if paginator.previous_page %}
     {% if paginator.page == 2 %}
-      <a class="pagination-item newer" href="{{ site.baseurl }}">Newer</a>
-    {% else %}
-      <a class="pagination-item newer" href="{{ site.baseurl }}page{{paginator.previous_page}}">Newer</a>
+      <a class="pagination-item newer" href="{{ paginator.previous_page_path }}">Newer</a>
     {% endif %}
   {% else %}
     <span class="pagination-item newer">Newer</span>


### PR DESCRIPTION
The complex combination of href to the previous/next pagination page doe not work when the paginated posts are not in base url.

Better use the [pagination attributes](https://jekyllrb.com/docs/pagination/).
