### PR TITLE
update liquid in sidebar.html to avoid mutliple entries for paginated resources

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -20,7 +20,9 @@
       {% assign pages_list = site.pages %}
       {% for node in pages_list %}
         {% if node.title != null %}
-          {% if node.layout == "page" %}
+          {% if node.url contains "page" %}
+            {% comment %} Do nothing {% endcomment %}
+          {% else %}
             <a class="sidebar-nav-item{% if page.url == node.url %} active{% endif %}" href="{{ node.url }}">{{ node.title }}</a>
           {% endif %}
         {% endif %}


### PR DESCRIPTION
Previously the template would generate multiple sidebar links to the same section if that section used `layout: page` and was paginated (i.e. blogs).

 Liquid now checks if the url of the node it is parsing contains 'page*', and if so, skips it. It will now only pick up the index.html files with` layout: page`