### PR TITLE
Fix run error when jekyll serve by deleting relative_permalinks

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,7 @@
 # Dependencies
 markdown:         redcarpet
 highlighter:      pygments
+plugins:          [jekyll-paginate, jekyll-gist]
 
 # Permalinks
 permalink:        pretty

--- a/_config.yml
+++ b/_config.yml
@@ -5,7 +5,6 @@ plugins:          [jekyll-paginate, jekyll-gist]
 
 # Permalinks
 permalink:        pretty
-relative_permalinks: true
 
 # Setup
 title:            Hyde


### PR DESCRIPTION
since relative_permalinks are deprecated, it will cause error when running with relative_permalinks: true configuration.