### PR TITLE
line removed from yml file 'relative_permalinks: true'

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,7 +4,7 @@ highlighter:      pygments
 
 # Permalinks
 permalink:        pretty
-relative_permalinks: true
+
 
 # Setup
 title:            Hyde


### PR DESCRIPTION
As per the message I received from GitHub:
This setting is deprecated as has been removed from the latest version of Jekyll. To ensure your site continues to build as expected, remove the option from your site's configuration and update any post or page permalinks to be absolute to the site root, not the parent folder. For more information, see https://help.github.com/articles/page-build-failed-relative-permalinks-configured/.
