### PR TITLE
switch from redcarpet to kramdown

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 # Dependencies
-markdown:         redcarpet
+markdown:         kramdown
 highlighter:      pygments
 
 # Permalinks


### PR DESCRIPTION
to support Jekyll 4.0.0. RedCarpet was dropped, see: https://jekyllrb.com/news/

The error you would otherwise get is: `Markdown processor: "redcarpet" is not a valid Markdown processor. Available processors are: kramdown`

I didn't check if the markdown needs changes..
(Also Pygments was also dropped, but I didn't change anything for that.)