### PR TITLE
Removed 'relative_permalink' in _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,7 +4,6 @@ highlighter:      pygments
 
 # Permalinks
 permalink:        pretty
-relative_permalinks: true
 
 # Setup
 title:            Hyde


### PR DESCRIPTION
After configuration. Github pages said that the current `relative_permalink` is no longer supported. Thus removing it in the base code.